### PR TITLE
Fix segments square sum calculation

### DIFF
--- a/models/locations.go
+++ b/models/locations.go
@@ -68,7 +68,7 @@ func GetSections(companySlug string) []SectionWithAmount {
 			"segments_section.*, "+
 				"count(distinct segments_rack.id) as racks_count, "+
 				"count(distinct segments_segment.id) as segments_count, "+
-				"sum(distinct segments_segment.square) as square_sum").
+				"sum(segments_segment.square) as square_sum").
 		Joins(
 			"join segments_company "+
 				"on segments_company.id = segments_section.company_id "+


### PR DESCRIPTION
## Summary
- fix the query that computes section square sums

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/..." Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/..." Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f550fbef48328b64787388227210e