### PR TITLE
Fix breadcrumbs link on segments search

### DIFF
--- a/templates/app/segments.html
+++ b/templates/app/segments.html
@@ -33,7 +33,7 @@
   <div class="row">
     <ol class="breadcrumb">
       <li><a href="/"><span class="glyphicon glyphicon-home"></span></a></li>
-      <li><a href="/{{ .Company.Slug }}">{{ .Company.Name }}</a></li>
+      <li><a href="/companies/{{ .Company.Slug }}">{{ .Company.Name }}</a></li>
       <li class="active">{{ .Section.Name }}</li>
     </ol>
     <div class="col-lg-12">


### PR DESCRIPTION
## Summary
- correct company link path in segments breadcrumbs

Closes #61 

------
https://chatgpt.com/codex/tasks/task_e_683fec9a01ac83289d7c3d03dfdec77b