### PR TITLE
Add paginator and validator tests

### DIFF
--- a/models/pagination_test.go
+++ b/models/pagination_test.go
@@ -1,0 +1,48 @@
+package models
+
+import "testing"
+
+func TestPaginator_GetOffset(t *testing.T) {
+	tests := []struct {
+		current int
+		want    int
+	}{
+		{1, 0},
+		{2, 10},
+		{5, 40},
+	}
+	for _, tt := range tests {
+		p := Paginator{Current: tt.current}
+		got := p.GetOffset()
+		if got != tt.want {
+			t.Errorf("Current %d: expected %d, got %d", tt.current, tt.want, got)
+		}
+	}
+}
+
+func TestPaginator_GetLimit(t *testing.T) {
+	p := Paginator{}
+	if p.GetLimit() != 10 {
+		t.Errorf("expected limit 10, got %d", p.GetLimit())
+	}
+}
+
+func TestPaginator_GetTotalPages(t *testing.T) {
+	tests := []struct {
+		items int64
+		want  int
+	}{
+		{0, 0},
+		{1, 1},
+		{10, 1},
+		{11, 2},
+		{99, 10},
+	}
+	for _, tt := range tests {
+		p := Paginator{TotalItems: tt.items}
+		got := p.GetTotalPages()
+		if got != tt.want {
+			t.Errorf("items %d: expected %d, got %d", tt.items, tt.want, got)
+		}
+	}
+}

--- a/models/validators_test.go
+++ b/models/validators_test.go
@@ -1,0 +1,48 @@
+package models
+
+import (
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	if err := db.AutoMigrate(&User{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	DB = db
+	return db
+}
+
+func TestCheckLogin_Success(t *testing.T) {
+	setupTestDB(t)
+	password := "secret"
+	hash := GeneratePasswordHash(password)
+	user := User{Username: "john", Password: hash}
+	DB.Create(&user)
+
+	u, err := CheckLogin(LoginForm{Username: "john", Password: password})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.ID == 0 || u.Username != user.Username {
+		t.Fatalf("returned user not correct")
+	}
+}
+
+func TestCheckLogin_NonexistentUser(t *testing.T) {
+	setupTestDB(t)
+	_, err := CheckLogin(LoginForm{Username: "nouser", Password: "pass"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	expected := "Формат пароля неверный"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %v", expected, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for pagination logic
- add tests for CheckLogin covering successful login and missing user

## Testing
- `go test ./...` *(fails: can't download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68414a3b22888328b7c8a6a2bb9d639e