### PR TITLE
Implement color management admin

### DIFF
--- a/admin/base.go
+++ b/admin/base.go
@@ -137,7 +137,96 @@ func DeleteColorType(c *gin.Context) {
 }
 
 func GetColors(c *gin.Context) {
-	c.HTML(200, "admin/colors.html", gin.H{"Colors": models.GetColors()})
+	c.HTML(200, "admin/colors.html", gin.H{
+		"Colors":     models.GetColors(),
+		"ColorTypes": models.GetColorTypes(),
+		"Form":       models.ColorForm{},
+	})
+}
+
+func CreateColor(c *gin.Context) {
+	var form models.ColorForm
+	if errs := GetFormErrors(&form, c); errs != nil {
+		c.HTML(400, "admin/colors.html", gin.H{
+			"Errors":     errs,
+			"Form":       form,
+			"Colors":     models.GetColors(),
+			"ColorTypes": models.GetColorTypes(),
+		})
+		return
+	}
+	_, err := models.CreateColor(form)
+	if err != nil {
+		c.HTML(400, "admin/colors.html", gin.H{
+			"Error":      err.Error(),
+			"Form":       form,
+			"Colors":     models.GetColors(),
+			"ColorTypes": models.GetColorTypes(),
+		})
+		return
+	}
+	c.Redirect(302, "/admin/colors")
+}
+
+func GetColorEditRow(c *gin.Context) {
+	id, err := GetUintId(c)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	color := models.GetColorById(id)
+	if color.ID == 0 {
+		c.Status(400)
+		return
+	}
+	c.HTML(200, "admin_color_edit_row", gin.H{
+		"Color":      color,
+		"ColorTypes": models.GetColorTypes(),
+	})
+}
+
+func GetColorViewRow(c *gin.Context) {
+	id, err := GetUintId(c)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	color := models.GetColorById(id)
+	if color.ID == 0 {
+		c.Status(400)
+		return
+	}
+	c.HTML(200, "admin_color_row", color)
+}
+
+func UpdateColorRow(c *gin.Context) {
+	id, err := GetUintId(c)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	var form models.ColorForm
+	c.Bind(&form)
+	color, err := models.UpdateColor(id, form)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	c.HTML(200, "admin_color_row", color)
+}
+
+func DeleteColor(c *gin.Context) {
+	id, err := GetUintId(c)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	err = models.DeleteColor(id)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	c.Status(200)
 }
 
 func GetSegments(c *gin.Context) {

--- a/main.go
+++ b/main.go
@@ -186,6 +186,14 @@ func main() {
 			colorTypeRouter.DELETE("/:id", admin.DeleteColorType)
 		}
 		adminRouter.GET("/colors", admin.GetColors)
+		colorsRouter := adminRouter.Group("/colors")
+		{
+			colorsRouter.POST("", admin.CreateColor)
+			colorsRouter.GET("/:id", admin.GetColorViewRow)
+			colorsRouter.GET("/:id/edit", admin.GetColorEditRow)
+			colorsRouter.PATCH("/:id", admin.UpdateColorRow)
+			colorsRouter.DELETE("/:id", admin.DeleteColor)
+		}
 		adminRouter.GET("/segments", admin.GetSegments)
 	}
 

--- a/models/forms.go
+++ b/models/forms.go
@@ -43,3 +43,9 @@ type LoginForm struct {
 	Username string `form:"username" binding:"required"`
 	Password string `form:"password" binding:"required"`
 }
+
+type ColorForm struct {
+	Name      string `form:"name" binding:"required"`
+	Slug      string `form:"slug" binding:"required,slug"`
+	ColorType string `form:"color_type" binding:"required"`
+}

--- a/templates/admin/colors.html
+++ b/templates/admin/colors.html
@@ -15,48 +15,38 @@
     </thead>
     <tbody hx-target="closest tr" hx-swap="outerHTML">
       {{ range .Colors }}
-      <tr>
-        <th scope="row">{{ .ID }}</th>
-        <td>{{ .Name }}</td>
-        <td>{{ .Slug }}</td>
-        <td>{{ .Type.Name }}</td>
-        <td class="text-center">
-          <div class="btn-group" role="group">
-            <button title="edit" hx-get="/admin/users/{{ .ID }}/edit" class="btn btn-light"><i class="bi bi-pencil"></i></button>
-            <button title="delete" hx-confirm="Are you sure?" hx-delete="/admin/users/{{ .ID }}" class="btn btn-danger"><i class="bi bi-trash"></i></button>
-          </div>
-        </td>
-      </tr>
+        {{ template "admin_color_row" . }}
       {{ end }}
     </tbody>
   </table>
   <div class="row">
     <div class="col-md-6 offset-md-3">
       <form method="post">
-        <legend>Create new color type</legend>
+        <legend>Create new color</legend>
         <div class="mb-3">
-          <input
-            id="slug-source"
-            class="form-control"
-            type="text"
-            name="name"
-            placeholder="name"
-            minlength="2"
-            value="{{ .Form.Name }}"
-            required
-          >
+          <input id="slug-source" class="form-control" type="text" name="name" placeholder="name" minlength="2" value="{{ .Form.Name }}" required>
         </div>
         <div class="mb-3">
-          <input
-            id="slug-target"
-            class="form-control"
-            type="text"
-            name="slug"
-            placeholder="slug"
-            value="{{ .Form.Slug }}"
-            disabled
-          >
+          <input id="slug-target" class="form-control" type="text" name="slug" placeholder="slug" value="{{ .Form.Slug }}" disabled>
         </div>
+        <div class="mb-3">
+          <select class="form-select" name="color_type" required>
+            <option value="">color type</option>
+            {{ $ct := .Form.ColorType }}
+            {{ range .ColorTypes }}
+              <option value="{{ .Slug }}" {{ if eq .Slug $ct }}selected{{ end }}>{{ .Name }}</option>
+            {{ end }}
+          </select>
+        </div>
+        {{ if .Errors }}
+        <div class="m-3 p-2 text-danger-emphasis bg-danger-subtle border border-danger-subtle rounded-3">
+          <ul>
+            {{ range .Errors }}
+            <li><b>{{ .Field }}</b> {{ .Message }}</li>
+            {{ end }}
+          </ul>
+        </div>
+        {{ end }}
         {{ if .Error }}
         <div class="m-3 p-2 text-primary-emphasis bg-primary-subtle border border-primary-subtle rounded-3">
           {{ .Error }}

--- a/templates/admin/colors_tmpl.html
+++ b/templates/admin/colors_tmpl.html
@@ -1,0 +1,36 @@
+{{ define "admin_color_row" }}
+<tr>
+  <th scope="row">{{ .ID }}</th>
+  <td>{{ .Name }}</td>
+  <td>{{ .Slug }}</td>
+  <td>{{ .Type.Name }}</td>
+  <td class="text-center">
+    <div class="btn-group" role="group">
+      <button title="edit" hx-get="/admin/colors/{{ .ID }}/edit" class="btn btn-light"><i class="bi bi-pencil"></i></button>
+      <button title="delete" hx-confirm="Are you sure?" hx-delete="/admin/colors/{{ .ID }}" class="btn btn-danger"><i class="bi bi-trash"></i></button>
+    </div>
+  </td>
+</tr>
+{{ end }}
+
+{{ define "admin_color_edit_row" }}
+<tr hx-trigger="cancel" class="editing" hx-get="/admin/colors/{{ .Color.ID }}">
+  <td>{{ .Color.ID }}</td>
+  <td><input type="text" class="form-control" name="name" value="{{ .Color.Name }}"></td>
+  <td><input type="text" class="form-control" name="slug" value="{{ .Color.Slug }}"></td>
+  <td>
+    <select name="color_type" class="form-select">
+      {{ $ct := .Color.Type.Slug }}
+      {{ range .ColorTypes }}
+        <option value="{{ .Slug }}" {{ if eq .Slug $ct }}selected{{ end }}>{{ .Name }}</option>
+      {{ end }}
+    </select>
+  </td>
+  <td class="text-center">
+    <div class="btn-group">
+      <button class="btn btn-secondary" hx-patch="/admin/colors/{{ .Color.ID }}" hx-include="closest tr"><i class="bi bi-floppy"></i></button>
+      <button class="btn btn-warning" hx-get="/admin/colors/{{ .Color.ID }}"><i class="bi bi-x-square"></i></button>
+    </div>
+  </td>
+</tr>
+{{ end }}


### PR DESCRIPTION
## Summary
- add `ColorForm` for admin operations
- support creating, updating and deleting colors in model layer
- expose new color handlers in admin
- register admin color routes
- implement color templates with partials

## Testing
- `go test ./...` *(fails: Forbidden errors)*

------
https://chatgpt.com/codex/tasks/task_e_68414bbb40848328b80d707e8a00f099