### PR TITLE
Add edit support for color types

### DIFF
--- a/admin/base.go
+++ b/admin/base.go
@@ -136,6 +136,36 @@ func DeleteColorType(c *gin.Context) {
 	c.Status(200)
 }
 
+func GetColorTypeEditRow(c *gin.Context) {
+	id, err := GetUintId(c)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	colorType := models.GetColorTypeById(id)
+	if colorType.ID == 0 {
+		c.Status(400)
+		return
+	}
+	c.HTML(200, "admin_color_type_edit_row", colorType)
+}
+
+func UpdateColorTypeRow(c *gin.Context) {
+	id, err := GetUintId(c)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	var form models.ColorTypeForm
+	c.Bind(&form)
+	colorType, err := models.UpdateColorType(id, form)
+	if err != nil {
+		c.Status(400)
+		return
+	}
+	c.HTML(200, "admin_color_type_row", colorType)
+}
+
 func GetColors(c *gin.Context) {
 	c.HTML(200, "admin/colors.html", gin.H{
 		"Colors":     models.GetColors(),

--- a/main.go
+++ b/main.go
@@ -183,6 +183,8 @@ func main() {
 		colorTypeRouter := adminRouter.Group("/color-types")
 		{
 			colorTypeRouter.POST("", admin.CreateColorType)
+			colorTypeRouter.GET("/:id/edit", admin.GetColorTypeEditRow)
+			colorTypeRouter.PATCH("/:id", admin.UpdateColorTypeRow)
 			colorTypeRouter.DELETE("/:id", admin.DeleteColorType)
 		}
 		adminRouter.GET("/colors", admin.GetColors)

--- a/models/colors.go
+++ b/models/colors.go
@@ -69,12 +69,24 @@ func CreateColorType(form ColorTypeForm) (ColorType, error) {
 	return colorType, nil
 }
 
-func UpdateColorType(slug string, form ColorTypeForm) (ColorType, error) {
-	colorType := ColorType{
-		Name: form.Name,
-		Slug: form.Slug,
+func GetColorTypeById(id uint) ColorType {
+	var colorType ColorType
+	DB.Where(&ColorType{ID: id}).First(&colorType)
+	return colorType
+}
+
+func UpdateColorType(id uint, form ColorTypeForm) (ColorType, error) {
+	colorType := GetColorTypeById(id)
+	if colorType.ID == 0 {
+		return ColorType{}, fmt.Errorf("color type not found")
 	}
-	result := DB.Where(&ColorType{Slug: slug}).Updates(&colorType)
+	if form.Name != "" {
+		colorType.Name = form.Name
+	}
+	if form.Slug != "" {
+		colorType.Slug = form.Slug
+	}
+	result := DB.Save(&colorType)
 	if result.Error != nil {
 		return ColorType{}, result.Error
 	}

--- a/templates/admin/color_types.html
+++ b/templates/admin/color_types.html
@@ -14,17 +14,7 @@
     </thead>
     <tbody hx-target="closest tr" hx-swap="outerHTML swap:1s">
       {{ range .ColorTypes }}
-      <tr>
-        <th scope="row">{{ .ID }}</th>
-        <td>{{ .Name }}</td>
-        <td>{{ .Slug }}</td>
-        <td class="text-center">
-          <div class="btn-group" role="group">
-            <button title="edit" hx-get="/admin/color-types/{{ .ID }}/edit" class="btn btn-light"><i class="bi bi-pencil"></i></button>
-            <button title="delete" hx-confirm="Are you sure?" hx-delete="/admin/color-types/{{ .ID }}" class="btn btn-danger"><i class="bi bi-trash"></i></button>
-          </div>
-        </td>
-      </tr>
+        {{ template "admin_color_type_row" . }}
       {{ end }}
     </tbody>
   </table>

--- a/templates/admin/color_types_tmpl.html
+++ b/templates/admin/color_types_tmpl.html
@@ -1,0 +1,27 @@
+{{ define "admin_color_type_row" }}
+<tr>
+  <th scope="row">{{ .ID }}</th>
+  <td>{{ .Name }}</td>
+  <td>{{ .Slug }}</td>
+  <td class="text-center">
+    <div class="btn-group" role="group">
+      <button title="edit" hx-get="/admin/color-types/{{ .ID }}/edit" class="btn btn-light"><i class="bi bi-pencil"></i></button>
+      <button title="delete" hx-confirm="Are you sure?" hx-delete="/admin/color-types/{{ .ID }}" class="btn btn-danger"><i class="bi bi-trash"></i></button>
+    </div>
+  </td>
+</tr>
+{{ end }}
+
+{{ define "admin_color_type_edit_row" }}
+<tr hx-trigger="cancel" class="editing" hx-get="/admin/color-types/{{ .ID }}">
+  <td>{{ .ID }}</td>
+  <td><input type="text" class="form-control" name="name" value="{{ .Name }}"></td>
+  <td><input type="text" class="form-control" name="slug" value="{{ .Slug }}"></td>
+  <td class="text-center">
+    <div class="btn-group">
+      <button class="btn btn-secondary" hx-patch="/admin/color-types/{{ .ID }}" hx-include="closest tr"><i class="bi bi-floppy"></i></button>
+      <button class="btn btn-warning" hx-get="/admin/color-types/{{ .ID }}"><i class="bi bi-x-square"></i></button>
+    </div>
+  </td>
+</tr>
+{{ end }}


### PR DESCRIPTION
## Summary
- add `admin_color_type_edit_row` and `admin_color_type_row` templates
- support editing color types in admin handlers
- expose color type edit routes

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68453b58df448328bdb2ec66f6addbb4