### PR TITLE
Fix company image layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -56,3 +56,18 @@ option {
 .username {
     padding-left: 5px;
 }
+
+/* Equal-size tiles for company images */
+.company-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 250px;
+}
+
+.company-tile img {
+    width: 200px;
+    height: 200px;
+    object-fit: contain;
+}

--- a/templates/app/companies.html
+++ b/templates/app/companies.html
@@ -8,8 +8,8 @@
     <div class="col-lg-12">
       <div class="row">
         {{ range .Companies }}
-          <div class="col-lg-6 text-center">
-            <a href="/companies/{{ .Slug }}">
+          <div class="col-lg-6">
+            <a href="/companies/{{ .Slug }}" class="company-tile text-center">
               <h2>{{ .Name }}</h2>
               <img src="{{ .ImageUrl }}" class="img-thumbnail" alt="{{ .Name }}">
             </a>


### PR DESCRIPTION
## Summary
- add `.company-tile` CSS class for equal-size company images
- wrap company links with `.company-tile` container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a85bb1ec48328b40e1304dda6e7ec